### PR TITLE
Nice idea Custom SDK Launcher!

### DIFF
--- a/Distroir.CustomSDKLauncher.Core/Resources/Templates.xml
+++ b/Distroir.CustomSDKLauncher.Core/Resources/Templates.xml
@@ -33,6 +33,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <GameDirName>Day of Defeat Source</GameDirName>
   </Template>
   <Template>
+    <Name>Day of Infamy</Name>
+    <GameinfoDirName>doi</GameinfoDirName>
+    <GameDirName>dayofinfamy</GameDirName>
+  </Template>
+  <Template>
     <Name>Garry's mod</Name>
     <GameinfoDirName>garrysmod</GameinfoDirName>
     <GameDirName>GarrysMod</GameDirName>

--- a/Distroir.CustomSDKLauncher.Core/Resources/Templates.xml
+++ b/Distroir.CustomSDKLauncher.Core/Resources/Templates.xml
@@ -18,6 +18,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ArrayOfTemplate xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Template>
+    <Name>Black Mesa</Name>
+    <GameinfoDirName>bms</GameinfoDirName>
+    <GameDirName>Black Mesa</GameDirName>
+  </Template>
+  <Template>
     <Name>Counter-Strike: Global Offensive</Name>
     <GameinfoDirName>csgo</GameinfoDirName>
     <GameDirName>Counter-Strike Global Offensive</GameDirName>

--- a/Distroir.CustomSDKLauncher.UI/Dialogs/ChooseTemplateDialog.Designer.cs
+++ b/Distroir.CustomSDKLauncher.UI/Dialogs/ChooseTemplateDialog.Designer.cs
@@ -39,10 +39,10 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.templateListView.Location = new System.Drawing.Point(17, 36);
-            this.templateListView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.templateListView.Margin = new System.Windows.Forms.Padding(4);
             this.templateListView.MultiSelect = false;
             this.templateListView.Name = "templateListView";
-            this.templateListView.Size = new System.Drawing.Size(344, 235);
+            this.templateListView.Size = new System.Drawing.Size(344, 265);
             this.templateListView.TabIndex = 0;
             this.templateListView.UseCompatibleStateImageBehavior = false;
             this.templateListView.View = System.Windows.Forms.View.List;
@@ -50,8 +50,8 @@
             // useButton
             // 
             this.useButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.useButton.Location = new System.Drawing.Point(263, 279);
-            this.useButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.useButton.Location = new System.Drawing.Point(263, 309);
+            this.useButton.Margin = new System.Windows.Forms.Padding(4);
             this.useButton.Name = "useButton";
             this.useButton.Size = new System.Drawing.Size(100, 28);
             this.useButton.TabIndex = 1;
@@ -73,12 +73,12 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(379, 322);
+            this.ClientSize = new System.Drawing.Size(379, 352);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.useButton);
             this.Controls.Add(this.templateListView);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "ChooseTemplateDialog";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/Distroir.CustomSDKLauncher.UI/Dialogs/FirstLaunchDialog.cs
+++ b/Distroir.CustomSDKLauncher.UI/Dialogs/FirstLaunchDialog.cs
@@ -36,7 +36,7 @@ namespace Distroir.CustomSDKLauncher.UI.Dialogs
             ReloadList();
 
             //Change game directory
-            directoryTextBox.Text = Utils.CombineDefaultGameDirName(TemplateManager.Templates[0].GameDirName);
+            directoryTextBox.Text = Utils.CombineDefaultGameDirName(TemplateManager.Templates[1].GameDirName);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Distroir.CustomSDKLauncher.UI.Dialogs
             }
 
             //Select first item
-            gameComboBox.SelectedIndex = 0;
+            gameComboBox.SelectedIndex = 1;
         }
 
         private void selectDirectoryButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
Hello Distroir, great job! - But I want give you big suggestion for Mono and UPX or VCPKG with zlib static x86.

I made mkbundle with "Custom SDK Launcher.exe" into bundled executable. "CustomSDKLauncher.exe" 20 mb and UPX to > 7 mb. And you don't need install Net Frameworks 4.x :) Because mkbundle is great bundler of net frameworks as "jit-compiler" or dotnet core.

I hope you allow me if I use mono into standalone executable. ( embedding assemblies into executable )

Keep your work!

Example bundled executable of Custom SDK Launcher.
https://mega.nz/#!xwpjxZxK!Mu_s1RTXu0dnLrzyiBzUC3_13jSZN_Ss7eNqCAKR_Gs
If you have errors than you have to install Mono Runtime whatever you would like that. Please reply me! I want listen that because I already re-compiled and re-installed mono runtime with cygwin-x86.

PS: Don't worry - it is my test. if you want show icon in bundled mono-application than you need to add icon-path after generated temp.c and add icon into temp.s ( Important because temp.s need to convert for embedding bytes from icon file like hxD or hex editor to bytes 1, 2, 3, ... )
And compile manuell from generated compile process of mkbundle. I hope you have to get bundled executable...

// EDIT:
Why do I need vcpkg?
If you use mkbundle -z --static --deps --keeptemp "Your app.exe" -o "Your generated bundled.exe" -v than you need to execute path from generated command line from generated mkbundle process "-I "Path-to-.include - zlib.h" and -L "Path to zlib.lib" or copy from vcpkg\installed\zlib-static-x86\include\* and vcpkg\installed\zlib-static-x86\lib\* to your output of debug or release directory of Custom SDK Launcher.exe than build again and it is standalone executable don't need install net frameworks :) Enjoy your bundled application!

If you have got errors and you make sure copy from mono-path-to-installed\include\mono-2.0\* mono-path-to-installed\lib\* all lib files into your debug or release of Custom SDK launcher than build again. It is really successful from compilation. And check if your executable works - If you are not sure than you need change from cl.exe line "/SUBSYSTEM:windows" to "/SUBSYSTEM:console" and generate again and check command line if it throws error example System.NullNotException or mscorlib need download errors. Please don't copy from C:\Windows\Microsoft.Net\frameworks\4.5! Copy just from "mono-path-to-installed\lib\mono\4.5\*.dll to your release or debug directory just copy before "copy "C:\mono_x86\lib\mono\4.5\*.dll ." - If you see before i18n assemblies couldn't found .

Remember Mono bundling is not only Net Frameworks mscorlib.dll just use mono's mscorlib.dll

// EDIT: If you have problem with wrong x64 of clang and cl from Visual Studio 2017 Community - you need build manuell.
1. Download gedit.exe for Windows because it can load and write external large temp.s file ( bytes ... ) Don't use Notepad or Notepad++! Because both stopped of process if they can not load large temp.s ( more than 10.000 lines ) That is why I have tested with gedit for Windows can write large than 10.000 lines of text. And install gedit for Windows and open temp.s with gedit for Windows!
2. Replace "assembly"_XXXXXXXXXXXXX to "_assembly"_XXXXXXXXXXXXXXX froM Ctrg + H and wait until all marked text "assembly" to "_assembly" than save temp.s and you see that progressbar shows. Until it is completed from saving. and Use  command line:
""C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\ClangC2\14.10.25903\bin\HostX86\clang.exe" -c -x assembler -o temp.s.obj temp.s"
And cl.exe in command line
"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\bin\HostX86\x86\cl.exe" /MD /I "C:\Program Files\Mono\include\mono-2.0" /I "." "temp.c" "temp.s.obj" /link /SUBSYSTEM:windows /ENTRY:mainCRTStartup /NODEFAULTLIB libmono-static-sgen.lib kernel32.lib version.lib ws2_32.lib mswsock.lib psapi.lib shell32.lib oleaut32.lib ole32.lib winmm.lib user32.lib advapi32.lib ucrt.lib vcruntime.lib msvcrt.lib oldnames.lib zlib.lib /LIBPATH:"C:\Program Files\Mono\lib" /LIBPATH:"." /OUT:"CustomSDKLauncher.exe"
Than you check generated bundled executable! If you don't see if it happens wioth mscorlib.dll or System.NullNotException errors you can use like this
"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\bin\HostX86\x86\cl.exe" /MD /I "C:\Program Files\Mono\include\mono-2.0" /I "." "temp.c" "temp.s.obj" /link **/SUBSYSTEM:console** /ENTRY:mainCRTStartup /NODEFAULTLIB libmono-static-sgen.lib kernel32.lib version.lib ws2_32.lib mswsock.lib psapi.lib shell32.lib oleaut32.lib ole32.lib winmm.lib user32.lib advapi32.lib ucrt.lib vcruntime.lib msvcrt.lib oldnames.lib zlib.lib /LIBPATH:"C:\Program Files\Mono\lib" /LIBPATH:"." /OUT:"CustomSDKLauncher.exe"

And type in command line CustomSDKLauncher.exe
Output:

> 
> Your release or debug>

It means OK! If you see errors than you need fix. Thanks!
Sorry my bad English! Thanks!